### PR TITLE
Update dlt_offline_trace.c

### DIFF
--- a/src/shared/dlt_offline_trace.c
+++ b/src/shared/dlt_offline_trace.c
@@ -64,6 +64,11 @@
 #include <dirent.h>
 
 #include <dlt_offline_trace.h>
+#include <syslog.h>
+#include "dlt_common.h"
+
+/* Size of buffer */
+#define DLT_DAEMON_TEXTBUFSIZE        512
 
 unsigned int dlt_offline_trace_storage_dir_info(char *path, char *file_name, char *newest, char *oldest)
 {
@@ -339,6 +344,31 @@ int dlt_offline_trace_delete_oldest_file(DltOfflineTrace *trace) {
 
 DltReturnValue dlt_offline_trace_check_size(DltOfflineTrace *trace) {
 
+    struct stat status;
+    char local_str[DLT_DAEMON_TEXTBUFSIZE] = { '\0' };
+
+    /* check for existence of offline trace directory */
+    if(stat(trace->directory, &status) == -1)
+    {
+	    snprintf(local_str,DLT_DAEMON_TEXTBUFSIZE,
+	             "Offline trace directory: %s doesn't exist \n",
+	              trace->directory);
+	    dlt_log(LOG_ERR,local_str);	
+        
+	    return -1;
+    }
+    
+    /* check for accesibilty of offline trace directory */
+    else if(access(trace->directory,  W_OK) != 0)
+    {
+	    snprintf(local_str,DLT_DAEMON_TEXTBUFSIZE,
+		  		 "Offline trace directory: %s doesn't have the write access \n",
+				  trace->directory);
+	    dlt_log(LOG_ERR,local_str);	
+        
+	    return -1;
+    }
+    
     /* check size of complete offline trace */
     while((int)dlt_offline_trace_get_total_size(trace) > (trace->maxSize-trace->fileSize))
     {

--- a/src/shared/dlt_offline_trace.c
+++ b/src/shared/dlt_offline_trace.c
@@ -67,9 +67,6 @@
 #include <syslog.h>
 #include "dlt_common.h"
 
-/* Size of buffer */
-#define DLT_DAEMON_TEXTBUFSIZE        512
-
 unsigned int dlt_offline_trace_storage_dir_info(char *path, char *file_name, char *newest, char *oldest)
 {
     int i = 0;
@@ -345,27 +342,18 @@ int dlt_offline_trace_delete_oldest_file(DltOfflineTrace *trace) {
 DltReturnValue dlt_offline_trace_check_size(DltOfflineTrace *trace) {
 
     struct stat status;
-    char local_str[DLT_DAEMON_TEXTBUFSIZE] = { '\0' };
 
     /* check for existence of offline trace directory */
     if(stat(trace->directory, &status) == -1)
     {
-	    snprintf(local_str,DLT_DAEMON_TEXTBUFSIZE,
-	             "Offline trace directory: %s doesn't exist \n",
-	              trace->directory);
-	    dlt_log(LOG_ERR,local_str);	
-        
+	    dlt_vlog(LOG_ERR, "Offline trace directory: %s doesn't exist \n", trace->directory);
 	    return -1;
     }
     
     /* check for accesibilty of offline trace directory */
     else if(access(trace->directory,  W_OK) != 0)
     {
-	    snprintf(local_str,DLT_DAEMON_TEXTBUFSIZE,
-		  		 "Offline trace directory: %s doesn't have the write access \n",
-				  trace->directory);
-	    dlt_log(LOG_ERR,local_str);	
-        
+	    dlt_vlog(LOG_ERR, "Offline trace directory: %s doesn't have the write access \n", trace->directory);
 	    return -1;
     }
     

--- a/src/shared/dlt_offline_trace.c
+++ b/src/shared/dlt_offline_trace.c
@@ -62,9 +62,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <syslog.h>
 
 #include <dlt_offline_trace.h>
-#include <syslog.h>
 #include "dlt_common.h"
 
 unsigned int dlt_offline_trace_storage_dir_info(char *path, char *file_name, char *newest, char *oldest)
@@ -344,17 +344,17 @@ DltReturnValue dlt_offline_trace_check_size(DltOfflineTrace *trace) {
     struct stat status;
 
     /* check for existence of offline trace directory */
-    if(stat(trace->directory, &status) == -1)
+    if (stat(trace->directory, &status) == -1)
     {
 	    dlt_vlog(LOG_ERR, "Offline trace directory: %s doesn't exist \n", trace->directory);
-	    return -1;
+	    return DLT_RETURN_ERROR;
     }
     
     /* check for accesibilty of offline trace directory */
     else if(access(trace->directory,  W_OK) != 0)
     {
 	    dlt_vlog(LOG_ERR, "Offline trace directory: %s doesn't have the write access \n", trace->directory);
-	    return -1;
+	    return DLT_RETURN_ERROR;
     }
     
     /* check size of complete offline trace */


### PR DESCRIPTION
Post enabling and updating “OfflineTraceDirectory” variable default path in dlt.conf file, dlt-daemon resulted in crash with Segmentation fault(SIGSEGV) due to Invalid OfflineTraceDirectory path.

dlt_offline_trace_patch-1 contains an update which verifies “existence of offline trace directory” and its “accessibility issues”. It returns -1 on failure conditions and indicates user with appropriate information instead resulting in APPCRASH.

Please let me know if you have any comments or questions.
